### PR TITLE
Feat: axios 인터셉터 구현 및 카카오 로그인 기능 구현

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,18 +1,64 @@
 import axios from 'axios';
 
-//axios config
 const axiosInstance = axios.create({
-  baseURL: 'localhost:9000',
+  baseURL: 'http://localhost:9000',
   withCredentials: true,
 });
 
-axiosInstance.interceptors.request.use((config) => {
-  // gettoken으로 토큰 받아옴
-  const token = 0;
-  if (token !== null) config.headers.Authorization = `Bearer ${token}`;
-  return config;
-});
+// Response Interceptor 설정 (일단은 accessToken이랑 refreshToken 때문에 response 만 생성했음)
+axiosInstance.interceptors.response.use(
+  (response) => {
+    // 성공적인 응답 처리
+    return response;
+  },
+  async (error) => {
+    // 에러 처리
+    const originalRequest = error.config;
+    // error.config에 들어있는것들
+    // url: 요청이 보내진 URL.
+    // method: 요청 방식 (예: 'get', 'post').
+    // data: 요청과 함께 보낸 데이터 (POST, PUT 요청의 경우).
+    // headers: 요청에 사용된 HTTP 헤더.
+    // params: URL 파라미터 (GET 요청의 경우).
+    // timeout: 요청의 타임아웃 설정.
 
-axiosInstance.interceptors.response.use();
+    if (error.response.status === 401 && !originalRequest._retry) {
+      //에러 401이면 accesstoken 유효기간 지난거
+      originalRequest._retry = true;
+
+      try {
+        // refreshToken으로 새 accessToken 요청
+        const refreshToken = localStorage.getItem('refreshToken');
+        //post 엔드포인트는 나중에 백한테 받고 변경해야 됨
+        const response = await axiosInstance.post('/refresh-token', {
+          refreshToken: refreshToken,
+        });
+
+        const { accessToken } = response.data;
+
+        // 새로운 accessToken 저장
+        localStorage.setItem('accessToken', accessToken);
+
+        // 새 accessToken으로 요청 헤더 설정
+        axiosInstance.defaults.headers.common[
+          'Authorization'
+        ] = `Bearer ${accessToken}`;
+        originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
+
+        // 원래 요청 재실행
+        return axiosInstance(originalRequest);
+      } catch (err) {
+        // 에러 처리
+        console.error('Error during token refresh:', err);
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        // 여기에 로그아웃 로직이나 로그인 페이지로의 리디렉션 추가 가능
+        return Promise.reject(err);
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export default axiosInstance;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -15,8 +15,6 @@ function Header() {
   const location = useLocation();
   const isLoginPath = location.pathname === '/login';
 
-  console.log(isLoginPath);
-  console.log(isAuth);
   return (
     <He.NavBar>
       <He.LeftSection>

--- a/src/oauth/Google/GoggleLogin.tsx
+++ b/src/oauth/Google/GoggleLogin.tsx
@@ -1,18 +1,10 @@
-import GoogleLogo from '../../pages/Loginpage/images/googlelogin.svg';
+import * as L from '../../pages/Loginpage/styles/Login.style';
 
 const GoogleLogin = () => {
   const handleGoogleLogin = () => {
     window.location.href = `http://localhost:5173/oauth2/authorize/google`;
   };
-
-  return (
-    <img
-      src={GoogleLogo}
-      alt="카카오 로고"
-      style={{ width: '80%', cursor: 'pointer', marginBottom: '10px' }}
-      onClick={handleGoogleLogin}
-    />
-  );
+  return <L.GoogleButton onClick={handleGoogleLogin} />;
 };
 
 export default GoogleLogin;

--- a/src/oauth/Kakao/KakaoLogin.tsx
+++ b/src/oauth/Kakao/KakaoLogin.tsx
@@ -1,4 +1,4 @@
-import KakaoLogo from '../../pages/Loginpage/images/kakaologin.svg';
+import * as L from '../../pages/Loginpage/styles/Login.style';
 
 const KakaoLogin = () => {
   const handleKakaoLogin = () => {
@@ -7,14 +7,7 @@ const KakaoLogin = () => {
     window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${apikey}&redirect_uri=${redirectUri}&response_type=code`;
   };
 
-  return (
-    <img
-      src={KakaoLogo}
-      alt="카카오 로고"
-      style={{ width: '80%', cursor: 'pointer', marginBottom: '10px' }}
-      onClick={handleKakaoLogin}
-    />
-  );
+  return <L.KakaoButton onClick={handleKakaoLogin} />;
 };
 
 export default KakaoLogin;

--- a/src/pages/Loginpage/Login.tsx
+++ b/src/pages/Loginpage/Login.tsx
@@ -6,6 +6,8 @@ import { Caption, TextRegular } from '../../components/common/Text';
 import { requestGet } from '../../util/http';
 import { useQuery } from '@tanstack/react-query';
 import { Key } from 'react';
+import KakaoLogin from '../../oauth/Kakao/KakaoLogin';
+import GoogleLogin from '../../oauth/Google/GoggleLogin';
 
 function Login() {
   const { data } = useQuery({
@@ -49,8 +51,8 @@ function Login() {
       <L.ButtonContainer>
         <L.SnsCaption> SNS 계정으로 로그인</L.SnsCaption>
         {content}
-        <L.KakaoButton />
-        <L.GoogleButton />
+        <KakaoLogin />
+        <GoogleLogin />
       </L.ButtonContainer>
     </MobileLayout>
   );

--- a/src/util/http.tsx
+++ b/src/util/http.tsx
@@ -1,7 +1,10 @@
-import axios from 'axios';
+import axiosInstance from '../api/axios';
+
+//여기는 그냥 테스트 질문들 받아오는 코드인데, 나중에 다른 컴포넌트로 옮겨야 할 듯.
+//임시 테스트 용 코드임
+
 export async function requestGet() {
-  const response = await axios.get('http://localhost:9000/api/test-question');
-  //console.log(response.data);
+  const response = await axiosInstance.get('/api/test-question');
   const questions = response.data;
   return questions;
 }


### PR DESCRIPTION
## 변경사항
- FE/병찬의 로그인 버튼에 FE/진수의 리다이렉트 기능 refactor
- axiosInstance의 response 부분에  대한 인터셉터 구현 
- axios 인터셉터의 response 부분은 401에러 발생 시 로컬 스토리지에 저장된 refreshToken을 보내서 accessToken 재발급 받는 기능
- Redirect.tsx에서 백엔드에 인증코드 보내고 accessToken, refreshToken 받은 후 로컬 스토리지에 저장하는 기능 구현

## 추가 구현 필요
- accessToken 재발급 받는 로직에서 에러가 발생할 시, 로그인페이지로 리다이렉트 되는 기능 구현 필요